### PR TITLE
Fix dependencies format

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -11,7 +11,7 @@ type: "python:3.7"
 
 # The build-time dependencies of the app.
 dependencies:
-    python:
+    python3:
        pipenv: '*'
 
 # The hooks executed at various points in the lifecycle of the application.


### PR DESCRIPTION
Python version in the dependencies section of the app config file should be now explicit, there was a backward incompatible change in Python dependencies format https://docs.platform.sh/configuration/app/build.html#python-dependencies.